### PR TITLE
meson: do not compile the library twice

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -53,10 +53,10 @@ libvarlink_a = static_library(
 libvarlink_sym = '@0@/@1@'.format(meson.current_source_dir(), 'libvarlink.sym')
 libvarlink_so = shared_library(
         'varlink',
-        libvarlink_sources,
         version : '0',
         link_args : ['-shared',
                      '-Wl,--version-script=' + libvarlink_sym],
+        link_whole : libvarlink_a,
         install : true)
 
 libvarlink_include = include_directories('.')


### PR DESCRIPTION
With autotools, the files comprising .a and .so libs were compiled just once to
form .a, and .so was created by using -Wl,--whole-archive. Meson supports this
too, with link_whole, but this options is only available since meson 0.40 and
not very well advertised, and it either wasn't available yet or I just missed it
when doing the initial conversion. Nevertheless, it works just fine, so let's
use it. This makes the builds a bit faster (20 .c files are not compiled twice),
but what more important, build warnings and errors are not printed twice.

The results are not byte-for-byte identical, but the file sizes and symbol
tables are.