### PR TITLE
Allow setting the bridge with an env var

### DIFF
--- a/tool/cli.c
+++ b/tool/cli.c
@@ -438,6 +438,7 @@ long cli_run(Cli *cli, int argc, char **argv) {
                 .timeout = -1
         };
         const CliCommand *command;
+        char *bridge;
         long r;
 
         r = cli_parse_arguments(argc, argv, &arguments);
@@ -446,6 +447,9 @@ long cli_run(Cli *cli, int argc, char **argv) {
 
         if (arguments.activate)
                 cli->activate = arguments.activate;
+
+        if ((bridge = getenv("VARLINK_BRIDGE")) != NULL)
+                cli->bridge = bridge;
 
         if (arguments.bridge)
                 cli->bridge = arguments.bridge;


### PR DESCRIPTION
Gets tedious to always use: --bridge="$VARLINK_BRIDGE"

Better if it can be given as an environment variable.