### PR TITLE
scanner: Fix parsing interface names

### DIFF
--- a/lib/test-interface.c
+++ b/lib/test-interface.c
@@ -72,7 +72,8 @@ static void test_name(void) {
                 _cleanup_(freep) char *string = NULL;
                 VarlinkInterface *interface;
 
-                assert(asprintf(&string, "interface %s", valid[i]) >= 0);
+                /* append some invalid interface characters in a comment */
+                assert(asprintf(&string, "interface %s\n#...--.?", valid[i]) >= 0);
                 assert(varlink_interface_new(&interface, string, NULL) == 0);
                 assert(varlink_interface_free(interface) == NULL);
         }


### PR DESCRIPTION
The `len` parameter was not taken into account for some of the checks in
interface_name_valid(). It has to be because the passed in parameter is
not 0-terminated.