### PR TITLE
Drop tags and ctags targets

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -79,25 +79,3 @@ subdir('lib')
 subdir('tool')
 subdir('vim')
 subdir('bash-completion')
-
-############################################################
-
-git = find_program('git', required : false)
-
-if git.found()
-        all_files = run_command(
-                git,
-                ['--git-dir=@0@/.git'.format(meson.current_source_dir()),
-                 'ls-files',
-                 ':/*.[ch]'])
-        all_files = files(all_files.stdout().split())
-
-        custom_target(
-                'tags',
-                output : 'tags',
-                command : ['env', 'etags', '-o', '@0@/TAGS'.format(meson.current_source_dir())] + all_files)
-        custom_target(
-                'ctags',
-                output : 'ctags',
-                command : ['env', 'ctags', '-o', '@0@/tags'.format(meson.current_source_dir())] + all_files)
-endif


### PR DESCRIPTION
meson 0.43 started providing a built-in ctags target which
conflicts with the hand-rolled one here. There shouldn't be
much difference, so let's drop ours.

Fixes #22.