### PR TITLE
Correct the float number parsing for some locales

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -15,7 +15,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install tools
-        run: sudo apt-get install valgrind meson
+        run: sudo apt-get install valgrind meson language-pack-de
+
+      - name: update locale
+        run: sudo locale-gen de_DE.UTF-8
 
       - name: make
         run: make

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install: build
 .PHONY: install
 
 check: build
-	meson test -C build --wrap=valgrind
+	meson test -C build --wrap=valgrind --print-errorlogs
 .PHONY: check
 
 format:

--- a/lib/scanner.c
+++ b/lib/scanner.c
@@ -4,7 +4,6 @@
 #include "util.h"
 #include "varlink.h"
 
-#include <locale.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -590,14 +589,8 @@ bool scanner_read_number(Scanner *scanner, ScannerNumber *numberp) {
                 return false;
 
         if (*end == '.' || *end == 'e' || *end == 'E') {
-                locale_t loc;
-
-                loc = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
-
                 number.is_double = true;
                 number.d = strtod(scanner->p, &end);
-
-                freelocale(loc);
         }
 
         scanner->p = end;

--- a/lib/value.c
+++ b/lib/value.c
@@ -7,7 +7,6 @@
 
 #include <float.h>
 #include <inttypes.h>
-#include <locale.h>
 
 void varlink_value_clear(VarlinkValue *value) {
         switch (value->kind) {
@@ -168,13 +167,8 @@ long varlink_value_write_json(VarlinkValue *value,
                         break;
 
                 case VARLINK_VALUE_FLOAT: {
-                        locale_t loc;
-
-                        loc = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
-
                         if (fprintf(stream, "%s%.*e%s", value_pre, DECIMAL_DIG, value->f, value_post) < 0)
                                 return -VARLINK_ERROR_PANIC;
-                        freelocale(loc);
                         break;
                 }
 

--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,7 @@ libm = cc.find_library('m')
 
 conf = configuration_data()
 conf.set('_GNU_SOURCE', true)
+conf.set('_XOPEN_SOURCE', 700)
 conf.set('__SANE_USERSPACE_TYPES__', true)
 conf.set_quoted('VERSION', meson.project_version())
 


### PR DESCRIPTION
* fix: correct the float number parsing for some locales
    
    Some locales use a different radix character for numbers.
    
    Modify the LC_NUMERIC locale for the two functions globally to correctly
    parse and write float numbers with a ".".
    
    This didn't work previously, because `uselocale()` was not called.
    
    Also use `duplocale()` to preserve a previously set locale and restore
    that with `uselocale()`.

* tests: add test with de_DE.UTF-8 locale
    
    de_DE.UTF-8 uses `,` as the radix character. Check if json parsing and
    writing switches to the C LC_NUMERIC.
