### PR TITLE
fix: use readelf with `--lto-syms` in case of LTO

### DIFF
--- a/lib/test-symbols.sh
+++ b/lib/test-symbols.sh
@@ -12,11 +12,31 @@ test -e "${libvarlink_a}" || exit 77
 
 rm -f symbols.list symbols.lib
 
-readelf -s -W "${libvarlink_a}" | grep 'FUNC    GLOBAL DEFAULT.*varlink_' | awk '{ print $8 }' | sort > symbols.list
-grep varlink_ "${libvarlink_sym}" | sed 's/[ ;]//g' | sort > symbols.lib
+if readelf -s -W "${libvarlink_a}" | grep -q 'FUNC    GLOBAL DEFAULT.*varlink_'; then
+	readelf -s -W "${libvarlink_a}" |
+		grep 'FUNC    GLOBAL DEFAULT.*varlink_' |
+		awk '{ print $8 }' |
+		sort >symbols.list
+elif readelf -s -W "${libvarlink_a}" | grep -q gnu_lto; then
+	if ! readelf -s -W --lto-syms "${libvarlink_a}" &>/dev/null; then
+		echo "readelf is too old and does not understand $(--lto-syms)" >&2
+		exit 77
+	fi
+
+	readelf -s -W --lto-syms "${libvarlink_a}" 2>/dev/null |
+		grep ' DEF.*DEFAULT.*FUNCTION.*varlink_' |
+		while read _ _ _ _ _ _ _ f; do
+			echo ${f#_}
+		done |
+		sort >symbols.list
+else
+	exit 1
+fi
+
+grep varlink_ "${libvarlink_sym}" | sed 's/[ ;]//g' | sort >symbols.lib
 diff -u symbols.list symbols.lib
 r=$?
 
 rm -f symbols.list symbols.lib
 
-exit $r;
+exit $r


### PR DESCRIPTION
In case LTO was activated, the gnu linker places the symbols in
.gnu.lto sections, which `readelf` prior to `2.36.1` did not understand.
Later versions support the `--lto-syms` option, which is now used for
the `test-symbols` test case.

Fixes: https://github.com/varlink/libvarlink/issues/30