### PR TITLE
scanner: no longer dump debug messages to stderr

### DIFF
--- a/lib/scanner.c
+++ b/lib/scanner.c
@@ -625,7 +625,6 @@ long scanner_expect_string(Scanner *scanner, char **stringp) {
         utf8_len = size;
         c_utf8_verify(&utf8_str, &utf8_len);
         if (utf8_len != 0) {
-                fprintf(stderr, "%ld != %ld\n", utf8_len, size);
                 scanner_error(scanner, SCANNER_ERROR_INVALID_CHARACTER);
                 return -VARLINK_ERROR_INVALID_JSON;
         }


### PR DESCRIPTION
When varlink_object_new_from_json is fuzzed it receives a lot of bogus json strings and clutters stderr with messages like "2 != 4" instead of just returning errors. Given that it's the only place where fprintf is used like that it seems it was left there accidentally and can probably be safely removed to make the API more consistent in general.

It should make it easier to fuzz the library and other than that it should also make it possible to compile libvarlink on some architectures without compiler warnings like
```
../lib/scanner.c:628:49: warning: format specifies type 'long' but the argument has type 'size_t' (aka 'unsigned int') [-Wformat]
                fprintf(stderr, "%ld != %ld\n", utf8_len, size);
                                 ~~~            ^~~~~~~~
                                 %zu
../lib/scanner.c:628:59: warning: format specifies type 'long' but the argument has type 'size_t' (aka 'unsigned int') [-Wformat]
                fprintf(stderr, "%ld != %ld\n", utf8_len, size);
                                        ~~~               ^~~~
                                        %zu
```