### PR TITLE
fix:uri: "varlink help" not working with camel-case interface names

### DIFF
--- a/lib/connection.c
+++ b/lib/connection.c
@@ -80,7 +80,7 @@ _public_ long varlink_connection_new(VarlinkConnection **connectionp, const char
         _cleanup_(varlink_uri_freep) VarlinkURI *uri = NULL;
         long r;
 
-        r = varlink_uri_new(&uri, address, false);
+        r = varlink_uri_new(&uri, address, false, false);
         if (r < 0)
                 return r;
 

--- a/lib/service.c
+++ b/lib/service.c
@@ -269,7 +269,7 @@ static long varlink_service_method_callback(VarlinkService *service,
         VarlinkMethod *method;
         long r;
 
-        r = varlink_uri_new(&uri, call->method, true);
+        r = varlink_uri_new(&uri, call->method, true, true);
         if (r < 0 || !uri->member)
                 return varlink_call_reply_invalid_parameter(call, call->method);
 
@@ -302,7 +302,7 @@ _public_ long varlink_service_new_raw(VarlinkService **servicep,
         service->listen_fd = -1;
         service->epoll_fd = -1;
 
-        r = varlink_uri_new(&service->uri, address, false);
+        r = varlink_uri_new(&service->uri, address, false, false);
         if (r < 0)
                 return r;
 
@@ -680,7 +680,7 @@ _public_ long varlink_call_reply_error(VarlinkCall *call,
         if (call != call->connection->call)
                 return -VARLINK_ERROR_INVALID_CALL;
 
-        r = varlink_uri_new(&uri_error, error, true);
+        r = varlink_uri_new(&uri_error, error, true, true);
         if (r < 0)
                 return r;
 
@@ -695,7 +695,7 @@ _public_ long varlink_call_reply_error(VarlinkCall *call,
         if (!member || member->type != VARLINK_MEMBER_ERROR)
                 return -VARLINK_ERROR_INVALID_IDENTIFIER;
 
-        r = varlink_uri_new(&uri_method, call->method, true);
+        r = varlink_uri_new(&uri_method, call->method, true, true);
         if (r < 0)
                 return r;
 

--- a/lib/transport.c
+++ b/lib/transport.c
@@ -26,7 +26,7 @@ _public_ int varlink_listen(const char *address, char **pathp) {
         _cleanup_(varlink_uri_freep) VarlinkURI *uri = NULL;
         long r;
 
-        r = varlink_uri_new(&uri, address, false);
+        r = varlink_uri_new(&uri, address, false, false);
         if (r < 0)
                 return (int) r;
 

--- a/lib/uri.c
+++ b/lib/uri.c
@@ -122,6 +122,11 @@ static long uri_parse_protocol(VarlinkURI *uri, const char *address, char **stri
  * to supply this information in `has_interface`, depending on the
  * context the URI is parsed.
  *
+ * Same happens with interface and member when the interface name
+ * is camel case, e.g: io.systemd.UserDatabase.GetUserRecord. The
+ * caller needs to supply this information in `has_member`, depending
+ * on the context the URI is parsed.
+ *
  * unix:/run/org.example.foo/org.example.foo.List?foo=bar#baz
  *   address:          unix:/run/org.example.foo
  *   protocol:         unix
@@ -132,7 +137,7 @@ static long uri_parse_protocol(VarlinkURI *uri, const char *address, char **stri
  *   query:            foo=bar
  *   fragment:         baz
  */
-long varlink_uri_new(VarlinkURI **urip, const char *address, bool has_interface) {
+long varlink_uri_new(VarlinkURI **urip, const char *address, bool has_interface, bool has_member) {
         _cleanup_(varlink_uri_freep) VarlinkURI *uri = NULL;
         _cleanup_(freep) char *string = NULL;
         char *p;
@@ -207,7 +212,7 @@ long varlink_uri_new(VarlinkURI **urip, const char *address, bool has_interface)
                 if (!p)
                         return -VARLINK_ERROR_INVALID_IDENTIFIER;
 
-                if (p[1] >= 'A' && p[1] <= 'Z') {
+                if (has_member) {
                         /* Split interface and member */
                         uri->qualified_member = uri->interface;
                         uri->interface = strndup(uri->interface, p - uri->interface);

--- a/lib/uri.h
+++ b/lib/uri.h
@@ -21,6 +21,6 @@ typedef struct {
         char *fragment;
 } VarlinkURI;
 
-long varlink_uri_new(VarlinkURI **urip, const char *uri, bool has_interface);
+long varlink_uri_new(VarlinkURI **urip, const char *uri, bool has_interface, bool has_member);
 VarlinkURI *varlink_uri_free(VarlinkURI *uri);
 void varlink_uri_freep(VarlinkURI **urip);

--- a/tool/cli.c
+++ b/tool/cli.c
@@ -615,7 +615,7 @@ long cli_complete_methods(Cli *cli, const char *current) {
         const char *description = NULL;
         long r;
 
-        r = varlink_uri_new(&uri, current, true);
+        r = varlink_uri_new(&uri, current, true, false);
         if (r < 0 || !uri->interface)
                 return cli_complete_interfaces(cli, current, true);
 

--- a/tool/command-bridge.c
+++ b/tool/command-bridge.c
@@ -229,7 +229,7 @@ static long handleBridge(Cli *cli, Bridge *bridge) {
                         _cleanup_(varlink_uri_freep) VarlinkURI *uri = NULL;
                         _cleanup_(freep) char *address = NULL;
 
-                        r = varlink_uri_new(&uri, method, true);
+                        r = varlink_uri_new(&uri, method, true, true);
                         if (r < 0) {
                                 bridge_reply(bridge, "org.varlink.service.InvalidParameter", NULL, 0);
                                 return -CLI_ERROR_INVALID_MESSAGE;
@@ -326,7 +326,7 @@ static long bridge_run(Cli *cli, int argc, char **argv) {
 
 
         if (connect) {
-                r = varlink_uri_new(&bridge_uri, connect, false);
+                r = varlink_uri_new(&bridge_uri, connect, false, false);
                 if (r < 0) {
                         fprintf(stderr, "Unable to parse --connect ADDRESS\n");
                         return -CLI_ERROR_INVALID_ARGUMENT;

--- a/tool/command-call.c
+++ b/tool/command-call.c
@@ -70,7 +70,7 @@ static long call_arguments_new(CallArguments **argumentsp, int argc, char **argv
         if (optind >= argc)
                 return -CLI_ERROR_MISSING_ARGUMENT;
 
-        r = varlink_uri_new(&arguments->uri, argv[optind], true);
+        r = varlink_uri_new(&arguments->uri, argv[optind], true, true);
         if (r < 0)
                 return -CLI_ERROR_INVALID_ARGUMENT;
 

--- a/tool/command-help.c
+++ b/tool/command-help.c
@@ -100,7 +100,7 @@ static long help_run(Cli *cli, int argc, char **argv) {
                 return -CLI_ERROR_MISSING_ARGUMENT;
         }
 
-        r = varlink_uri_new(&uri, argv[optind], true);
+        r = varlink_uri_new(&uri, argv[optind], true, false);
         if (r < 0 || !uri->interface) {
                 fprintf(stderr, "Unable to parse ADDRESS/INTERFACE\n");
                 return -CLI_ERROR_INVALID_ARGUMENT;

--- a/tool/command-info.c
+++ b/tool/command-info.c
@@ -114,7 +114,7 @@ static long info_run(Cli *cli, int argc, char **argv) {
 
         address = argv[optind];
         if (address) {
-                r = varlink_uri_new(&uri, address, false);
+                r = varlink_uri_new(&uri, address, false, false);
                 if (r < 0) {
                         fprintf(stderr, "Unable to parse ADDRESS\n");
                         return -CLI_ERROR_INVALID_ARGUMENT;


### PR DESCRIPTION
The varlink specification does not mandate that interface names are lower-case so it is not possible to know if an uri string contains a member or not based on last member capitalization.

This information must be provided by the caller depending on the context the URI is parsed.

Signed-off-by: Samuel Cabrero <scabrero@suse.de>