### PR TITLE
Fix: VarlinkStream not dispatching out data when write returns EAGAIN

### DIFF
--- a/lib/service.c
+++ b/lib/service.c
@@ -658,8 +658,16 @@ _public_ long varlink_call_reply(VarlinkCall *call,
                 return r;
 
         /* We did not write all data, wake up when we can write to the socket. */
-        if (r == 0)
+        if (r == 0) {
                 call->connection->events_mask |= EPOLLOUT;
+
+                r = service_connection_set_events_mask(
+                            call->service, call->connection,
+                            call->connection->events_mask);
+                if (r < 0) {
+                        return r;
+                }
+        }
 
         if (!(flags & VARLINK_REPLY_CONTINUES))
                 varlink_call_remove_from_connection(call);


### PR DESCRIPTION
The connection's fd event mask was updated with EPOLLOUT, but service_connection_set_events_masks() was not called to apply it.

Signed-off-by: Samuel Cabrero <scabrero@suse.de>