### PR TITLE
Fix: Integer overflow in write_docstring pointer arithmetic

### DIFF
--- a/lib/interface.c
+++ b/lib/interface.c
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>
+#include <limits.h>
 
 static long write_docstring(FILE *stream,
                             long indent,
@@ -16,8 +17,8 @@ static long write_docstring(FILE *stream,
                             const char *description) {
         for (const char *start = description; *start;) {
                 const char *end = strchrnul(start, '\n');
-                // FIXME assert < INT_MAX
-                int len = end - start;
+                ptrdiff_t diff = end - start;
+                int len = (diff > INT_MAX) ? INT_MAX : (int)diff;
 
                 for (long l = 0; l < indent; l += 1)
                         if (fprintf(stream, "  ") < 0)


### PR DESCRIPTION
The pointer difference `end - start` is of type ptrdiff_t which could exceed INT_MAX for very long docstrings. This fixes a FIXME comment that warned about the potential overflow when assigning to int len.

The fix properly handles the conversion by clamping to INT_MAX before casting to int, ensuring safe behavior even with extremely long input strings.