### PR TITLE
Update .packit.yaml: rename synced_files to files_to_sync

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,7 +4,7 @@
 specfile_path: libvarlink.spec
 
 # add or remove files that should be synced
-synced_files:
+files_to_sync:
     - libvarlink.spec
     - .packit.yaml
 


### PR DESCRIPTION
## Summary
Updated the `.packit.yaml` configuration file to use the correct Packit configuration key name.

## Changes
- Renamed `synced_files` to `files_to_sync` in `.packit.yaml`
  - This aligns with the current Packit schema and ensures proper file synchronization between the upstream repository and Fedora package management

## Details
The `files_to_sync` key is the correct configuration parameter in modern versions of Packit for specifying which files should be synchronized. This change ensures the configuration is compatible with the current Packit tooling and prevents potential configuration validation errors.

https://claude.ai/code/session_015UNZtRjpJaKTsafpnwAUc2