### PR TITLE
chore: update version format to semver

### DIFF
--- a/libvarlink.spec
+++ b/libvarlink.spec
@@ -1,7 +1,7 @@
 %global _hardened_build 1
 
 Name:           libvarlink
-Version:        24
+Version:        24.0.0
 Release:        1%{?dist}
 Summary:        Varlink C Library
 License:        ASL 2.0 and BSD-3-Clause

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libvarlink', 'c',
-        version : '24',
+        version : '24.0.0',
         license : ['Apache-2.0', 'BSD-3-Clause'],
         default_options: [
                 'c_std=gnu99',


### PR DESCRIPTION
Update version from '24' to '24.0.0' in meson.build and libvarlink.spec to align with release-please semver requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)