### PR TITLE
transport,tool: use const for strchr return pointers

### DIFF
--- a/lib/transport-device.c
+++ b/lib/transport-device.c
@@ -7,7 +7,7 @@
 #include <fcntl.h>
 
 static int strip_parameters(const char *address, char **devicep) {
-        char *parm;
+        const char *parm;
         _cleanup_(freep) char *device = NULL;
 
         parm = strchr(address, ';');

--- a/lib/transport-tcp.c
+++ b/lib/transport-tcp.c
@@ -10,7 +10,7 @@
 #include <sys/socket.h>
 
 static int strip_parameters(const char *address, char **hostp) {
-        char *parm;
+        const char *parm;
         _cleanup_(freep) char *host = NULL;
 
         parm = strchr(address, ';');
@@ -34,7 +34,7 @@ static void freeaddrinfop(struct addrinfo **ai) {
 static int resolve_addrinfo(const char *address, struct addrinfo **resultp) {
         _cleanup_(freep) char *host = NULL;
         char *endptr;
-        char *port;
+        const char *port;
         struct addrinfo hints = {
                 .ai_family = AF_UNSPEC,
                 .ai_socktype = SOCK_STREAM,

--- a/lib/transport-unix.c
+++ b/lib/transport-unix.c
@@ -10,7 +10,7 @@
 #include <unistd.h>
 
 static int strip_parameters(const char *address, char **pathp) {
-        char *parm;
+        const char *parm;
         _cleanup_(freep) char *path = NULL;
 
         parm = strchr(address, ';');

--- a/tool/command-format.c
+++ b/tool/command-format.c
@@ -155,7 +155,7 @@ static long format_run(Cli *UNUSED(cli), int argc, char **argv) {
 static long format_complete(Cli *cli, int argc, char **UNUSED(argv), const char *current) {
         _cleanup_(freep) char *prefix = NULL;
         DIR *dir;
-        char *p;
+        const char *p;
 
         if (argc != 1)
                 return 0;

--- a/tool/command-info.c
+++ b/tool/command-info.c
@@ -137,7 +137,7 @@ static long info_run(Cli *cli, int argc, char **argv) {
 static long info_complete(Cli *UNUSED(cli), int argc, char **UNUSED(argv), const char *current) {
         _cleanup_(freep) char *prefix = NULL;
         DIR *dir;
-        char *p;
+        const char *p;
 
         if (argc != 1)
                 return 0;


### PR DESCRIPTION
Fixes errors seen after c23 implemented in glibc

lib/transport-device.c:13:14: error: assigning to 'char *' from 'const char *' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
   13 |         parm = strchr(address, ';');
      |              ^ ~~~~~~~~~~~~~~~~~~~~
1 error generated.