### PR TITLE
Add configurable connection buffer size

### DIFF
--- a/lib/stream.c
+++ b/lib/stream.c
@@ -9,8 +9,6 @@
 #include <unistd.h>
 #include <sys/epoll.h>
 
-#define CONNECTION_BUFFER_SIZE (16 * 1024 * 1024)
-
 long varlink_stream_new(VarlinkStream **streamp, int fd) {
         _cleanup_(freep) VarlinkStream *stream = NULL;
 

--- a/meson.build
+++ b/meson.build
@@ -50,11 +50,23 @@ endforeach
 
 libm = cc.find_library('m')
 
+buffer_size_choice = get_option('connection-buffer-size')
+buffer_size_value = buffer_size_choice.substring(0, -3).to_int()
+
+if buffer_size_choice.endswith('KiB')
+        buffer_size = buffer_size_value * 1024
+elif buffer_size_choice.endswith('MiB')
+        buffer_size = buffer_size_value * 1024 * 1024
+else
+        error('Invalid buffer size format: @0@'.format(buffer_size_choice))
+endif
+
 conf = configuration_data()
 conf.set('_GNU_SOURCE', true)
 conf.set('_XOPEN_SOURCE', 700)
 conf.set('__SANE_USERSPACE_TYPES__', true)
 conf.set_quoted('VERSION', meson.project_version())
+conf.set('CONNECTION_BUFFER_SIZE', buffer_size)
 
 config_h = configure_file(
         output : 'config.h',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,5 @@
+option('connection-buffer-size',
+       type: 'combo',
+       choices: ['64KiB', '128KiB', '256KiB', '512KiB', '1MiB', '2MiB', '4MiB', '8MiB', '16MiB'],
+       value: '16MiB',
+       description: 'Size of connection buffers')


### PR DESCRIPTION
Hello!

I'm working on a project where we are running varlink on an embedded system with limited memory. The current hardcoded 16 MiB connection buffer size adds up fast when you use multiple varlink connections.

I've added the build time option `connection-buffer-size` that allows customizing the buffer size. The default remains 16 MiB, so existing behavior is unchanged.

Testing with the current minimum option 64 KiB
```
$ meson setup builddir-embedded -Dconnection-buffer-size=64KiB
The Meson build system
Version: 1.3.2
...
libvarlink 24.0.0

  User defined options
    connection-buffer-size: 1MiB

Found ninja-1.11.1 at /usr/bin/ninja


$ meson test -C builddir-embedded
...
323/326 n_array_double_extra_comma.json                                         EXPECTEDFAIL    8.31s   killed by signal 6 SIGABRT
324/326 n_array_heterogeneous.json                                              EXPECTEDFAIL    9.33s   killed by signal 6 SIGABRT
325/326 n_array_colon_instead_of_comma.json                                     EXPECTEDFAIL   10.40s   killed by signal 6 SIGABRT
326/326 n_structure_open_array_comma.json                                       EXPECTEDFAIL   10.32s   killed by signal 6 SIGABRT

Ok:                 111
Expected Fail:      215
Fail:               0
Unexpected Pass:    0
Skipped:            0
Timeout:            0
```

Thanks!